### PR TITLE
refactor: remove liquibase support in db ext

### DIFF
--- a/src/main/java/io/surati/gap/database/utils/extensions/DatabaseSetupExtension.java
+++ b/src/main/java/io/surati/gap/database/utils/extensions/DatabaseSetupExtension.java
@@ -16,7 +16,6 @@
  */
 package io.surati.gap.database.utils.extensions;
 
-import com.baudoliver7.easy.liquibase4j.gen.UncheckedLiquibaseDataSource;
 import com.baudoliver7.jdbc.toolset.lockable.LocalLockedDataSource;
 import com.baudoliver7.jdbc.toolset.wrapper.DataSourceWrap;
 import java.sql.Connection;
@@ -39,14 +38,11 @@ public final class DatabaseSetupExtension extends DataSourceWrap implements Afte
     /**
      * Ctor.
      * @param src Data source
-     * @param changelog Change log path
      */
-    public DatabaseSetupExtension(final DataSource src, final String changelog) {
+    public DatabaseSetupExtension(final DataSource src) {
         super(
             new LocalLockedDataSource(
-                new UncheckedLiquibaseDataSource(
-                    src, changelog
-                ),
+                src,
                 DatabaseSetupExtension.CONNECTION
             )
         );

--- a/src/test/java/io/surati/gap/database/utils/extensions/DatabaseSetupExtensionTest.java
+++ b/src/test/java/io/surati/gap/database/utils/extensions/DatabaseSetupExtensionTest.java
@@ -16,9 +16,10 @@
  */
 package io.surati.gap.database.utils.extensions;
 
+import com.baudoliver7.easy.liquibase4j.gen.UncheckedLiquibaseDataSource;
 import com.jcabi.jdbc.JdbcSession;
 import com.jcabi.jdbc.Outcome;
-import com.lightweight.db.EmbeddedPostgreSQLDataSource;
+import com.lightweight.db.EmbeddedH2DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 import org.hamcrest.MatcherAssert;
@@ -46,8 +47,10 @@ final class DatabaseSetupExtensionTest {
      */
     @RegisterExtension
     final DatabaseSetupExtension src = new DatabaseSetupExtension(
-        new EmbeddedPostgreSQLDataSource(),
-        "liquibase/db.changelog-master.xml"
+        new UncheckedLiquibaseDataSource(
+            new EmbeddedH2DataSource(),
+            "liquibase/db.changelog-master.xml"
+        )
     );
 
     /**


### PR DESCRIPTION
We refactored class `DatabaseSetupExtension`.

Fix: #35